### PR TITLE
Added margin

### DIFF
--- a/public/modcard.css
+++ b/public/modcard.css
@@ -23,6 +23,7 @@
   background: linear-gradient(35deg, #511e6a, #9c138f, #b695ce);
   border-radius: 15px;
   padding: 1rem;
+  margin-top: 8.563rem;
 }
 
 .modcard-name {


### PR DESCRIPTION

<img width="960" alt="modcardfix" src="https://user-images.githubusercontent.com/92370865/160830122-3b271c1d-7715-464b-9321-c66fa0828cd3.PNG">
<img width="374" alt="modcardfix1" src="https://user-images.githubusercontent.com/92370865/160830131-d9b0b360-188b-4f4f-8a61-e9680ec3bb7f.PNG">
Added margin so that the modcard doesn't overlay the navbar. 
it works for min 500px screen size.

# Pull Request

<!--Before contributing, please read our contributing guidelines: https://github.com/nhcommunity/homepage/blob/main/CONTRIBUTING.md-->

## Description

<!--A brief description of what your pull request does.-->
Solves the issue that I was talking about earlier
https://github.com/nhcommunity/homepage/issues/49

## Related Issue

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #XXXXX
